### PR TITLE
Fix parsing of search queries

### DIFF
--- a/lib/memento/entry/query.ex
+++ b/lib/memento/entry/query.ex
@@ -31,7 +31,7 @@ defmodule Memento.Entry.Query do
     from e in initial,
       where:
         fragment(
-          "to_tsvector('english', content) @@ to_tsquery(?)",
+          "to_tsvector('english', content) @@ plainto_tsquery(?)",
           ^search_query
         )
   end


### PR DESCRIPTION
Search queries with spaces would fail with the following error:

```
2020-06-06T07:28:15.237578+00:00 app[web.1]: 07:28:15.237 [error] GenServer #PID<0.818.0> terminating
2020-06-06T07:28:15.237590+00:00 app[web.1]: ** (Postgrex.Error) ERROR 42601 (syntax_error) syntax error in tsquery: "Game :*"
2020-06-06T07:28:15.237591+00:00 app[web.1]:     (ecto_sql 3.4.4) lib/ecto/adapters/sql.ex:593: Ecto.Adapters.SQL.raise_sql_call_error/1
2020-06-06T07:28:15.237592+00:00 app[web.1]:     (ecto_sql 3.4.4) lib/ecto/adapters/sql.ex:526: Ecto.Adapters.SQL.execute/5
2020-06-06T07:28:15.237592+00:00 app[web.1]:     (ecto 3.4.4) lib/ecto/repo/queryable.ex:192: Ecto.Repo.Queryable.execute/4
2020-06-06T07:28:15.237592+00:00 app[web.1]:     (ecto 3.4.4) lib/ecto/repo/queryable.ex:17: Ecto.Repo.Queryable.all/3
2020-06-06T07:28:15.237593+00:00 app[web.1]:     (memento 0.1.0) lib/memento_web/live/entries_live.ex:27: MementoWeb.EntriesLive.handle_params/3
2020-06-06T07:28:15.237594+00:00 app[web.1]:     (phoenix_live_view 0.13.0) lib/phoenix_live_view/channel.ex:445: 
```

The solution is to use plainto_tsquery, which applies default transformations to convert a plain string to a valid boolean search.

See https://www.postgresql.org/docs/11/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES